### PR TITLE
 Corrige preenchimento dos campos nos Adapters

### DIFF
--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -15,8 +15,10 @@ class PaymentController {
 
     def save() {
         try {
+            Long customerId = 1
+
             PaymentAdapter adapter = new PaymentAdapter(params)
-            Payment payment = paymentService.save(adapter)
+            Payment payment = paymentService.save(adapter, customerId)
 
             redirect (action: "show", id: payment.id)
         } catch (Exception exception) {

--- a/grails-app/services/com/mini/asaas/customer/CustomerAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CustomerAdapter.groovy
@@ -12,7 +12,7 @@ class CustomerAdapter extends BasePersonAdapter {
     public CustomerAdapter(Map params){
         this.cpfCnpj = Utils.removeNoNumeric(params.cpfCnpj.toString())
         this.name = params.name.toString().trim()
-        this.email = params.email.toString().trim()
+        this.email = params.email
         this.phone = Utils.removeNoNumeric(params.phone.toString()) ?: null
         this.mobilePhone = Utils.removeNoNumeric(params.mobilePhone.toString())
         this.personType = PersonType.convert(params.personType.toString().toUpperCase())

--- a/grails-app/services/com/mini/asaas/customer/CustomerAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CustomerAdapter.groovy
@@ -11,17 +11,17 @@ class CustomerAdapter extends BasePersonAdapter {
 
     public CustomerAdapter(Map params){
         this.cpfCnpj = Utils.removeNoNumeric(params.cpfCnpj.toString())
-        this.name = params.name
-        this.email = params.email
-        this.phone = Utils.removeNoNumeric(params.phone.toString())
+        this.name = params.name.toString().trim()
+        this.email = params.email.toString().trim()
+        this.phone = Utils.removeNoNumeric(params.phone.toString()) ?: null
         this.mobilePhone = Utils.removeNoNumeric(params.mobilePhone.toString())
         this.personType = PersonType.convert(params.personType.toString().toUpperCase())
         this.postalCode = Utils.removeNoNumeric(params.postalCode.toString())
-        this.address = params.address
-        this.addressNumber = params.addressNumber
-        this.addressComplement = (params.addressComplement.toString().trim()) ? params.addressComplement : null
-        this.district = params.district
-        this.city = params.city
-        this.state = params.state
+        this.address = params.address.toString().trim()
+        this.addressNumber = params.addressNumber.toString().trim()
+        this.addressComplement = params.addressComplement.toString().trim() ?: null
+        this.district = params.district.toString().trim()
+        this.city = params.city.toString().trim()
+        this.state = params.state.toString().trim()
     }
 }

--- a/grails-app/services/com/mini/asaas/payer/PayerAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerAdapter.groovy
@@ -1,6 +1,7 @@
 package com.mini.asaas.payer
 
 import com.mini.asaas.domain.base.BasePersonAdapter
+import com.mini.asaas.utils.Utils
 import com.mini.asaas.utils.base.PersonType
 
 import grails.compiler.GrailsCompileStatic
@@ -9,18 +10,18 @@ import grails.compiler.GrailsCompileStatic
 class PayerAdapter extends BasePersonAdapter {
 
     public PayerAdapter(Map params) {
-        this.cpfCnpj = params.cpfCnpj
-        this.name = params.name
-        this.email = params.email
-        this.phone = params.phone
-        this.mobilePhone = params.mobilePhone
+        this.cpfCnpj = Utils.removeNoNumeric(params.cpfCnpj.toString())
+        this.name = params.name.toString().trim()
+        this.email = params.email.toString().trim()
+        this.phone = Utils.removeNoNumeric(params.phone.toString()) ?: null
+        this.mobilePhone = Utils.removeNoNumeric(params.mobilePhone.toString())
         this.personType = PersonType.convert(params.personType.toString().toUpperCase())
-        this.postalCode = params.postalCode
-        this.address = params.address
-        this.addressNumber = params.addressNumber
-        this.addressComplement = (params.addressComplement.toString().trim()) ? params.addressComplement : null
-        this.district = params.district
-        this.city = params.city
-        this.state = params.state
+        this.postalCode = Utils.removeNoNumeric(params.postalCode.toString())
+        this.address = params.address.toString().trim()
+        this.addressNumber = params.addressNumber.toString().trim()
+        this.addressComplement = params.addressComplement.toString().trim() ?: null
+        this.district = params.district.toString().trim()
+        this.city = params.city.toString().trim()
+        this.state = params.state.toString().trim()
     }
 }

--- a/grails-app/services/com/mini/asaas/payment/PaymentAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentAdapter.groovy
@@ -2,15 +2,13 @@ package com.mini.asaas.payment
 
 import com.mini.asaas.utils.FormatUtils
 import com.mini.asaas.utils.Utils
-import com.mini.asaas.utils.enums.PaymentStatus
 import com.mini.asaas.utils.enums.BillingType
+import com.mini.asaas.utils.enums.PaymentStatus
 
 import grails.compiler.GrailsCompileStatic
 
 @GrailsCompileStatic
 class PaymentAdapter {
-
-    Long customerId
 
     Long payerId
 
@@ -23,7 +21,6 @@ class PaymentAdapter {
     Date dueDate
 
     public PaymentAdapter(Map params) {
-        this.customerId = 1
         this.payerId = 1
         this.billingType = BillingType.convert(params.billingType.toString().toUpperCase())
         this.value = Utils.toBigDecimal(params.value.toString())

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -10,10 +10,11 @@ import grails.gorm.transactions.Transactional
 @Transactional
 class PaymentService {
 
-    public Payment save(PaymentAdapter adapter) {
+    public Payment save(PaymentAdapter adapter, Long customerId) {
         Payment payment = new Payment()
 
         paymentBuildProperties(payment, adapter)
+        payment.customer = Customer.read(customerId)
 
         payment.save(failOnError: true)
 
@@ -39,7 +40,6 @@ class PaymentService {
     }
 
     private paymentBuildProperties(Payment payment, PaymentAdapter adapter) {
-        payment.customer = Customer.read(adapter.customerId)
         payment.payer = Payer.read(adapter.payerId)
         payment.billingType = adapter.billingType
         payment.value = adapter.value


### PR DESCRIPTION
### Impacto

- Remove customerId de PaymentAdapter, fazendo com que seja passado diretamente do Controller para o Service
- Remove espaços em branco nas extremidades dos campos, para impedir que sejam preenchidos apenas com espaços em branco
- Garante que o campo telefone será substituído por `null` caso seja deixado em branco, assim como já é feito com o complemento do endereço

### PR Predecessora

### Link da tarefa no GitHub Projects

### Link dos mockups

### Prints do desenvolvimento
