### PR TITLE
Adiciona dependências que estavam faltando para o quartz

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         classpath "org.grails.plugins:hibernate5:7.1.0"
         classpath "gradle.plugin.com.github.erdi.webdriver-binaries:webdriver-binaries-gradle-plugin:2.6"
         classpath "com.bertramlabs.plugins:asset-pipeline-gradle:3.3.4"
+        classpath "org.grails.plugins:quartz:2.0.13"
     }
 }
 
@@ -58,6 +59,7 @@ dependencies {
     implementation "org.grails.plugins:events"
     implementation "org.grails.plugins:gsp"
     implementation 'org.grails.plugins:quartz:2.0.13'
+    implementation "org.quartz-scheduler:quartz:2.2.1"
     profile "org.grails.profiles:web"
     runtimeOnly "org.glassfish.web:el-impl:2.2.1-b05"
     runtimeOnly "com.h2database:h2"

--- a/grails-app/jobs/com/mini/asaas/DueDatePaymentJob.groovy
+++ b/grails-app/jobs/com/mini/asaas/DueDatePaymentJob.groovy
@@ -2,10 +2,8 @@ package com.mini.asaas
 
 import com.mini.asaas.payment.PaymentService
 
-import grails.compiler.GrailsCompileStatic
 import grails.gorm.transactions.Transactional
 
-@GrailsCompileStatic
 class DueDatePaymentJob {
 
     static triggers = {

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -79,7 +79,7 @@ class PaymentService {
     }
 
     public void processOverduePayments() {
-        List<Long> overduePaymentsIds = Payment.overdueIds()
+        List<Long> overduePaymentsIds = Payment.overdueIds() as List<Long>
 
         if (overduePaymentsIds.isEmpty()) return
 


### PR DESCRIPTION
### Impacto

- Adiciona dependências que faltavam para o quartz
- Remove GrailsCompileStatic de DueDatePaymentJob
- Adiciona cast de lista em PaymentService.processOverduePayments()
- Ainda não foi possível consertar a IndexOutOfBoundsException, que continua impedindo a compilação

### PR Predecessora

### Link da tarefa no GitHub Projects

### Link dos mockups

### Prints do desenvolvimento
