### PR TITLE
Verifica CPF/CNPJ repetido em cadastro de Customer

### DIFF
--- a/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
@@ -117,6 +117,10 @@ class CustomerService {
     private Customer validateSave(CreateCustomerAdapter adapter) {
         Customer customer = validate(adapter)
 
+        if (Customer.findByCpfCnpj(adapter.cpfCnpj)) {
+            customer.errors.reject("cpfCnpj", null, "CPF/CNPJ já cadastrado")
+        }
+
         if (!CpfCnpjValidator.isValidCpfCnpj(adapter.cpfCnpj)) {
             customer.errors.reject("cpfCnpj", null, "CPF/CNPJ inválido")
         }


### PR DESCRIPTION
### Impacto

- Verifica se já existe um Customer cadastrado com o CPF/CNPJ passado na tentativa de cadastro e, caso exista, cria um erro de validação

### PR Predecessora

### Link da tarefa no GitHub Projects

[Verificar CPF/CNPJ único em CustomerService](https://github.com/orgs/TrioParadaDuraa/projects/1/views/1?pane=issue&itemId=66061554)

### Link dos mockups

### Prints do desenvolvimento
