### PR TITLE
Remove queries dos Controllers de Payer e Payment

### DIFF
--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -48,8 +48,9 @@ class PayerController extends BaseController {
 
         try {
             Map filterList = Utils.getFilterListFromParams(params, allowedFilters)
+            filterList.customerId = getCurrentCustomerId()
 
-            List<Payer> payerList = payerService.list(filterList, getCurrentCustomerId())
+            List<Payer> payerList = payerService.list(filterList)
 
             return [payerList: payerList]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -65,20 +65,10 @@ class PayerController extends BaseController {
 
     def update() {
         try {
-            Long id = params.long("id")
-
-            Payer payer = (Payer) Payer.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payer) {
-                throw new Exception("Pagador não encontrado")
-            } else if (payer.deleted) {
-                throw new Exception("Pagador está inativo")
-            }
-
             PayerAdapter adapter = new PayerAdapter(params)
-            payer = payerService.update(payer.id, adapter)
+            payerService.update(params.long("id"), getCurrentCustomerId(), adapter)
 
-            redirect(action: "show", id: payer.id)
+            redirect(action: "show", id: params.id)
         } catch (ValidationException validationException) {
             flash.errors = validationException.errors
         
@@ -91,17 +81,7 @@ class PayerController extends BaseController {
 
     def delete() {
         try {
-            Long id = params.long("id")
-
-            Payer payer = (Payer) Payer.query([customerId: getCurrentCustomerId(), id: id]).get()
-            
-            if (!payer) {
-                throw new Exception("Pagador não encontrado")
-            } else if (payer.deleted) {
-                throw new Exception("Pagador já está inativo")
-            }
-
-            payerService.delete(payer.id)
+            payerService.delete(params.long("id"), getCurrentCustomerId())
 
             redirect(action: "list")
         } catch (Exception exception) {
@@ -112,17 +92,7 @@ class PayerController extends BaseController {
 
     def restore() {
         try {
-            Long id = params.long("id")
-
-            Payer payer = (Payer) Payer.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payer) {
-                throw new Exception("Pagador não encontrado")
-            } else if (!payer.deleted) {
-                throw new Exception("Pagador não está inativo")
-            }
-
-            payerService.restore(payer.id)
+            payerService.restore(params.long("id"), getCurrentCustomerId())
 
             redirect(action: "list")
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -34,7 +34,7 @@ class PayerController extends BaseController {
 
     def show() {
         try{
-            Payer payer = payerService.find(params.long("id"), getCurrentCustomerId())
+            Payer payer = payerService.find([id: params.long("id"), customerId: getCurrentCustomerId()])
 
             return [payer: payer]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -48,13 +48,8 @@ class PayerController extends BaseController {
 
         try {
             Map filterList = Utils.getFilterListFromParams(params, allowedFilters)
-            filterList.put("cutomerId", getCurrentCustomerId())
 
-            if (!filterList.containsKey("deleted")) {
-                filterList.deleted = false
-            }
-
-            List<Payer> payerList = (List<Payer>) Payer.query(filterList).list()
+            List<Payer> payerList = payerService.list(filterList, getCurrentCustomerId())
 
             return [payerList: payerList]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payer/PayerController.groovy
@@ -34,13 +34,7 @@ class PayerController extends BaseController {
 
     def show() {
         try{
-            Long id = params.long("id")
-
-            Payer payer = (Payer) Payer.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payer) {
-                throw new Exception("Pagador não encontrado")
-            }
+            Payer payer = payerService.find(params.long("id"), getCurrentCustomerId())
 
             return [payer: payer]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -2,6 +2,7 @@ package com.mini.asaas.payment
 
 import com.mini.asaas.BaseController
 import com.mini.asaas.payer.Payer
+import com.mini.asaas.payer.PayerService
 
 import com.mini.asaas.utils.Utils
 import com.mini.asaas.utils.message.MessageType
@@ -15,8 +16,10 @@ class PaymentController extends BaseController {
 
     PaymentService paymentService
 
+    PayerService payerService
+
     def index() {
-        List<Payer> payerList = Payer.list()
+        List<Payer> payerList = payerService.list([:], getCurrentCustomerId())
 
         return [payerList: payerList]
     }
@@ -38,13 +41,7 @@ class PaymentController extends BaseController {
 
     def show() {
         try {
-            Long id = params.long('id')
-
-            Payment payment = (Payment) Payment.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payment) {
-                throw new Exception("Cobrança não encontrada")
-            }
+            Payment payment = paymentService.find(params.long('id'), getCurrentCustomerId())
 
             return [payment: payment]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -53,21 +53,10 @@ class PaymentController extends BaseController {
 
     def updateStatus() {
         try {
-            Long id = params.long('id')
-
-            Payment payment = (Payment) Payment.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payment) {
-                throw new Exception("Cobrança não encontrada")
-            } else if (payment.deleted) {
-                throw new Exception("Cobrança inativa")
-            }
-
             PaymentStatus status = PaymentStatus.convert(params.status)
+            paymentService.updateStatus(params.long('id'), status)
 
-            paymentService.updateStatus(payment.id, status)
-
-            redirect(action: "show", id: payment.id)
+            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             log.error("PaymentController.update >> Erro ao atualizar status", exception)
             flash.type = MessageType.ERROR

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -74,19 +74,9 @@ class PaymentController extends BaseController {
 
     def delete() {
         try {
-            Long id = params.long('id')
+            paymentService.delete(params.long('id'), getCurrentCustomerId())
 
-            Payment payment = (Payment) Payment.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payment) {
-                throw new Exception("Cobrança não encontrada")
-            } else if (payment.deleted) {
-                throw new Exception("Cobrança já inativa")
-            }
-
-            paymentService.delete(payment.id)
-
-            redirect(action: "show", id: payment.id)
+            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             log.error("PaymentController.delete >> Erro ao excluir cobrança", exception)
             render "Não foi possível excluir a cobrança"
@@ -95,19 +85,9 @@ class PaymentController extends BaseController {
 
     def restore() {
         try {
-            Long id = params.long('id')
+            paymentService.restore(params.long('id'), getCurrentCustomerId())
 
-            Payment payment = (Payment) Payment.query([customerId: getCurrentCustomerId(), id: id]).get()
-
-            if (!payment) {
-                throw new Exception("Cobrança não encontrada")
-            } else if (!payment.deleted) {
-                throw new Exception("Cobrança não inativa")
-            }
-
-            paymentService.restore(payment.id)
-
-            redirect(action: "show", id: payment.id)
+            redirect(action: "show", id: params.id)
         } catch (Exception exception) {
             log.error("PaymentController.restore >> Erro ao restaurar cobrança", exception)
             render "Não foi possivel restaurar a cobrança"

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -91,8 +91,9 @@ class PaymentController extends BaseController {
 
         try {
             Map filterList = Utils.getFilterListFromParams(params, allowedFilters)
+            filterList.customerId = getCurrentCustomerId()
             
-            List<Payment> paymentList = paymentService.list(filterList, getCurrentCustomerId())
+            List<Payment> paymentList = paymentService.list(filterList)
 
             return [paymentList: paymentList]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -20,7 +20,7 @@ class PaymentController extends BaseController {
     PayerService payerService
 
     def index() {
-        List<Payer> payerList = payerService.list([:], getCurrentCustomerId())
+        List<Payer> payerList = payerService.list([customerId: getCurrentCustomerId()])
 
         return [payerList: payerList]
     }

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -99,13 +99,8 @@ class PaymentController extends BaseController {
 
         try {
             Map filterList = Utils.getFilterListFromParams(params, allowedFilters)
-            filterList.put("cutomerId", getCurrentCustomerId())
-
-            if (!filterList.containsKey("deleted")) {
-                filterList.deleted = false
-            }
-
-            List<Payment> paymentList = Payment.query(filterList).list() as List<Payment>
+            
+            List<Payment> paymentList = paymentService.list(filterList, getCurrentCustomerId())
 
             return [paymentList: paymentList]
         } catch (Exception exception) {

--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -41,7 +41,7 @@ class PaymentController extends BaseController {
 
     def show() {
         try {
-            Payment payment = paymentService.find(params.long('id'), getCurrentCustomerId())
+            Payment payment = paymentService.find([id: params.long('id'), customerId: getCurrentCustomerId()])
 
             return [payment: payment]
         } catch (Exception exception) {

--- a/grails-app/domain/com/mini/asaas/payer/Payer.groovy
+++ b/grails-app/domain/com/mini/asaas/payer/Payer.groovy
@@ -12,10 +12,12 @@ class Payer extends BasePerson {
 
     static namedQueries = {
         query { Map filterList ->
-            if (filterList.deleted == "true") {
-                eq("deleted", true)
-            } else {
-                eq("deleted", false)
+            if (filterList.containsKey("deleted")) {
+                if (Boolean.valueOf(filterList.deleted)) {
+                    eq("deleted", true)
+                } else {
+                    eq("deleted", false)
+                }
             }
             
             if (filterList.containsKey("customerId")) {

--- a/grails-app/domain/com/mini/asaas/payer/Payer.groovy
+++ b/grails-app/domain/com/mini/asaas/payer/Payer.groovy
@@ -12,12 +12,10 @@ class Payer extends BasePerson {
 
     static namedQueries = {
         query { Map filterList ->
-            if (filterList.containsKey("deleted")) {
-                if (Boolean.valueOf(filterList.deleted)) {
-                    eq("deleted", true)
-                } else {
-                    eq("deleted", false)
-                }
+            if (filterList.deleted == "true") {
+                eq("deleted", true)
+            } else {
+                eq("deleted", false)
             }
             
             if (filterList.containsKey("customerId")) {

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -41,7 +41,10 @@ class PayerService {
     }
 
     public List<Payer> list(Map filterList, Long customerId) {
-        filterList.put("cutomerId", customerId)
+        if (!filterList.containsKey("deleted")) {
+            filterList.deleted = false
+        }
+        filterList.put("customerId", customerId)
 
         List<Payer> payerList = Payer.query(filterList).list() as List<Payer>
     }

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -42,9 +42,9 @@ class PayerService {
         if (!filterList.containsKey("deleted")) {
             filterList.deleted = false
         }
-        filterList.put("customerId", customerId)
+        filterList.customerId = customerId
 
-        List<Payer> payerList = Payer.query(filterList).list() as List<Payer>
+        return Payer.query(filterList).list() as List<Payer>
     }
 
     public void update(Long payerId, Long customerId, PayerAdapter adapter) {

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -40,30 +40,40 @@ class PayerService {
         return payer
     }
 
-    public Payer update(Long payerId, PayerAdapter adapter) {
-        Payer payer = validate(adapter)
+    public void update(Long payerId, Long customerId, PayerAdapter adapter) {
+        Payer payer = find(payerId, customerId)
 
-        if (payer.hasErrors()) throw new ValidationException("Erro ao salvar payer", payer.errors)
+        if (payer.deleted) {
+            throw new RuntimeException("Pagador está inativo")
+        }
 
-        payer = Payer.get(payerId)
+        Payer validPayer = validate(adapter)
+
+        if (validPayer.hasErrors()) throw new ValidationException("Erro ao salvar payer", validPayer.errors)
 
         buildPayerProperties(payer, adapter)
 
         payer.save(failOnError: true)
-        
-        return payer
     }
 
-    public void delete(Long payerId) {
-        Payer payer = Payer.get(payerId)
+    public void delete(Long payerId, Long customerId) {
+        Payer payer = find(payerId, customerId)
+
+        if (payer.deleted) {
+            throw new RuntimeException("Pagador já está inativo")
+        }
 
         payer.deleted = true
 
         payer.save(failOnError: true)
     }
 
-    public void restore(Long payerId) {
-        Payer payer = Payer.get(payerId)
+    public void restore(Long payerId, Long customerId) {
+        Payer payer = find(payerId, customerId)
+
+        if (!payer.deleted) {
+            throw new RuntimeException("Pagador não está inativo")
+        }
         
         payer.deleted = false
 

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -20,7 +20,7 @@ class PayerService {
     public Payer save(PayerAdapter adapter, Long customerId) {
         Payer payer = validate(adapter)
 
-        if (payer.hasErrors()) throw new ValidationException("Erro ao salvar payer", payer.errors)
+        if (payer.hasErrors()) throw new ValidationException("Erro ao salvar pagador", payer.errors)
 
         buildPayerProperties(payer, adapter)
         payer.customer = Customer.read(customerId)
@@ -30,8 +30,8 @@ class PayerService {
         return payer
     }
 
-    public Payer find(Long payerId, Long customerId) {
-        Payer payer = Payer.query([customerId: customerId, id: payerId]).get() as Payer
+    public Payer find(Map filterList) {
+        Payer payer = Payer.query(filterList).get() as Payer
 
         if (!payer) throw new RuntimeException("Pagador não encontrado")
 
@@ -48,7 +48,7 @@ class PayerService {
     }
 
     public void update(Long payerId, Long customerId, PayerAdapter adapter) {
-        Payer payer = find(payerId, customerId)
+        Payer payer = find([id: payerId, customerId: customerId])
 
         if (payer.deleted) throw new RuntimeException("Pagador está inativo")
 
@@ -62,7 +62,7 @@ class PayerService {
     }
 
     public void delete(Long payerId, Long customerId) {
-        Payer payer = find(payerId, customerId)
+        Payer payer = find([id: payerId, customerId: customerId])
 
         if (payer.deleted) throw new RuntimeException("Pagador já está inativo")
 
@@ -72,7 +72,7 @@ class PayerService {
     }
 
     public void restore(Long payerId, Long customerId) {
-        Payer payer = find(payerId, customerId)
+        Payer payer = find([id: payerId, customerId: customerId])
 
         if (!payer.deleted) throw new RuntimeException("Pagador não está inativo")
         

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -38,11 +38,10 @@ class PayerService {
         return payer
     }
 
-    public List<Payer> list(Map filterList, Long customerId) {
+    public List<Payer> list(Map filterList) {
         if (!filterList.containsKey("deleted")) {
             filterList.deleted = false
         }
-        filterList.customerId = customerId
 
         return Payer.query(filterList).list() as List<Payer>
     }

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -33,9 +33,7 @@ class PayerService {
     public Payer find(Long payerId, Long customerId) {
         Payer payer = Payer.query([customerId: customerId, id: payerId]).get() as Payer
 
-        if (!payer) {
-            throw new RuntimeException("Pagador não encontrado")
-        }
+        if (!payer) throw new RuntimeException("Pagador não encontrado")
 
         return payer
     }
@@ -52,9 +50,7 @@ class PayerService {
     public void update(Long payerId, Long customerId, PayerAdapter adapter) {
         Payer payer = find(payerId, customerId)
 
-        if (payer.deleted) {
-            throw new RuntimeException("Pagador está inativo")
-        }
+        if (payer.deleted) throw new RuntimeException("Pagador está inativo")
 
         Payer validPayer = validate(adapter)
 
@@ -68,9 +64,7 @@ class PayerService {
     public void delete(Long payerId, Long customerId) {
         Payer payer = find(payerId, customerId)
 
-        if (payer.deleted) {
-            throw new RuntimeException("Pagador já está inativo")
-        }
+        if (payer.deleted) throw new RuntimeException("Pagador já está inativo")
 
         payer.deleted = true
 
@@ -80,9 +74,7 @@ class PayerService {
     public void restore(Long payerId, Long customerId) {
         Payer payer = find(payerId, customerId)
 
-        if (!payer.deleted) {
-            throw new RuntimeException("Pagador não está inativo")
-        }
+        if (!payer.deleted) throw new RuntimeException("Pagador não está inativo")
         
         payer.deleted = false
 

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -31,13 +31,19 @@ class PayerService {
     }
 
     public Payer find(Long payerId, Long customerId) {
-        Payer payer = (Payer) Payer.query([customerId: customerId, id: payerId]).get()
+        Payer payer = Payer.query([customerId: customerId, id: payerId]).get() as Payer
 
         if (!payer) {
             throw new RuntimeException("Pagador não encontrado")
         }
 
         return payer
+    }
+
+    public List<Payer> list(Map filterList, Long customerId) {
+        filterList.put("cutomerId", customerId)
+
+        List<Payer> payerList = Payer.query(filterList).list() as List<Payer>
     }
 
     public void update(Long payerId, Long customerId, PayerAdapter adapter) {

--- a/grails-app/services/com/mini/asaas/payer/PayerService.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerService.groovy
@@ -30,6 +30,16 @@ class PayerService {
         return payer
     }
 
+    public Payer find(Long payerId, Long customerId) {
+        Payer payer = (Payer) Payer.query([customerId: customerId, id: payerId]).get()
+
+        if (!payer) {
+            throw new RuntimeException("Pagador não encontrado")
+        }
+
+        return payer
+    }
+
     public Payer update(Long payerId, PayerAdapter adapter) {
         Payer payer = validate(adapter)
 

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -31,9 +31,7 @@ class PaymentService {
     public Payment find(Long paymentId, Long customerId) {
         Payment payment = Payment.query([customerId: customerId, id: paymentId]).get() as Payment
 
-        if (!payment) {
-            throw new Exception("Cobrança não encontrada")
-        }
+        if (!payment) throw new Exception("Cobrança não encontrada")
 
         return payment
     }
@@ -46,16 +44,20 @@ class PaymentService {
         payment.save(failOnError: true)
     }
 
-    public void delete(Long paymentId) {
-        Payment payment = Payment.get(paymentId)
+    public void delete(Long paymentId, Long customerId) {
+        Payment payment = find(paymentId, customerId)
+
+        if (payment.deleted) throw new Exception("Cobrança já inativa")
 
         payment.deleted = true
 
         payment.save(failOnError: true)
     }
 
-    public void restore(Long paymentId) {
-        Payment payment = Payment.get(paymentId)
+    public void restore(Long paymentId, Long customerId) {
+        Payment payment = find(paymentId, customerId)
+
+        if (!payment.deleted) throw new Exception("Cobrança não inativa")
         
         payment.deleted = false
 

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -35,11 +35,10 @@ class PaymentService {
         return payment
     }
 
-    public List<Payment> list(Map filterList, Long customerId) {
+    public List<Payment> list(Map filterList) {
         if (!filterList.containsKey("deleted")) {
             filterList.deleted = false
         }
-        filterList.customerId = customerId
 
         return Payment.query(filterList).list() as List<Payment>
     }

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -36,6 +36,15 @@ class PaymentService {
         return payment
     }
 
+    public List<Payment> list(Map filterList, Long customerId) {
+        if (!filterList.containsKey("deleted")) {
+            filterList.deleted = false
+        }
+        filterList.customerId = customerId
+
+        return Payment.query(filterList).list() as List<Payment>
+    }
+
     public void update(Long paymentId, PaymentAdapter adapter) {
         Payment payment = Payment.get(paymentId)
 

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -106,7 +106,11 @@ class PaymentService {
 
     public void updateStatus(Long paymentId, PaymentStatus status) {
         Payment payment = find([id: paymentId])
+
+        if (payment.deleted && status != PaymentStatus.OVERDUE) throw new Exception("Cobrança inativa")
+
         payment.status = status
+
         payment.save(failOnError: true)
     }
 }

--- a/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
+++ b/grails-app/services/com/mini/asaas/payment/PaymentService.groovy
@@ -28,6 +28,16 @@ class PaymentService {
         return payment
     }
 
+    public Payment find(Long paymentId, Long customerId) {
+        Payment payment = Payment.query([customerId: customerId, id: paymentId]).get() as Payment
+
+        if (!payment) {
+            throw new Exception("Cobrança não encontrada")
+        }
+
+        return payment
+    }
+
     public void update(Long paymentId, PaymentAdapter adapter) {
         Payment payment = Payment.get(paymentId)
 


### PR DESCRIPTION
### Impacto

- Cria métodos de busca no banco nos Services de Payer e Payment para remover dos Controllers queries e tratamento de exceções relacionadas à busca
- Substitui método findPayment, que era usado nos métodos relacionados ao job de vencimento de cobranças, pelo novo método find

### PR Predecessora

### Link da tarefa no GitHub Projects

[Mover busca no banco e tratamento de exceções nos Controllers de Payer e Payment para seus Services](https://github.com/orgs/TrioParadaDuraa/projects/1?pane=issue&itemId=66040201)

### Link dos mockups

### Prints do desenvolvimento
