### PR TITLE
Corrige bug no valor da data usada no job de vencimento

### DIFF
--- a/grails-app/domain/com/mini/asaas/payment/Payment.groovy
+++ b/grails-app/domain/com/mini/asaas/payment/Payment.groovy
@@ -6,6 +6,8 @@ import com.mini.asaas.payer.Payer
 import com.mini.asaas.utils.enums.PaymentStatus
 import com.mini.asaas.utils.enums.BillingType
 
+import org.apache.commons.lang.time.DateUtils
+
 class Payment extends BaseDomain {
 
     Customer customer
@@ -48,7 +50,7 @@ class Payment extends BaseDomain {
             projections {
                 property('id')
             }
-            lt('dueDate', new Date())
+            lt('dueDate', DateUtils.truncate(new Date(), Calendar.DAY_OF_MONTH))
             not {
                 inList('status', [PaymentStatus.RECEIVED, PaymentStatus.RECEIVED_IN_CASH, PaymentStatus.OVERDUE])
             }


### PR DESCRIPTION
### Impacto

- A query realizada no job acabava levando em conta hora, minuto, segundo e milissegundo, fazendo com que cobranças fossem marcadas como vencidas na data de vencimento, ao invés de apenas após essa data.

### PR Predecessora

### Link da tarefa no GitHub Projects

### Link dos mockups

### Prints do desenvolvimento
