### PR TITLE
Criação de página de erro de visualização de cobrança

### DIFF
--- a/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
+++ b/grails-app/controllers/com/mini/asaas/payment/PaymentController.groovy
@@ -47,7 +47,7 @@ class PaymentController extends BaseController {
             return [payment: payment]
         } catch (Exception exception) {
             log.error("PaymentController.show >> Erro ao exibir cobrança", exception)
-            render "Cobrança não encontrada"
+            render view: /error/
         }
     }
 

--- a/grails-app/views/payment/error.gsp
+++ b/grails-app/views/payment/error.gsp
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="pt-br">
+    <head>
+        <meta name="layout" content="error">
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Cobrança não encontrada</title>
+    </head>
+    <body>
+        <atlas-empty-state
+            illustration="flow-money-coins"
+            header="Não foi possível carregar os dados da cobrança"
+        >
+            Aqui você pode retornar para as cobranças.
+            <atlas-button
+                description="Acessar cobranças"
+                href="${createLink(controller: 'payment', action: 'list')}"
+                slot="button"
+            ></atlas-button>
+        </atlas-empty-state>
+    </body>
+</html>


### PR DESCRIPTION
### Impacto (Descrever o que foi feito)
- Cria a página de erro de visualização de cobrança;
- Adiciona render view no catch do método show do controller de payment.

### PR Predecessora (Caso exista dependência de uma PR ou branch existente)
[71](https://github.com/TrioParadaDuraa/mini-asaas/pull/71)
### Link da tarefa no GitHub Projects

### Link dos mockups (Se houver)

### Prints do desenvolvimento

![image](https://github.com/TrioParadaDuraa/mini-asaas/assets/102339220/9441b65d-e9d2-4310-9c4e-3e5123aadba4)
