### PR TITLE
Exibição de erros ao cadastrar Customer

### DIFF
--- a/grails-app/assets/javascripts/errorMessage.js
+++ b/grails-app/assets/javascripts/errorMessage.js
@@ -1,7 +1,10 @@
-setTimeout(function() {
-    var errorMessage = document.getElementById('error-message');
-    errorMessage.classList.add('hide');
+document.addEventListener('DOMContentLoaded', function() {
     setTimeout(function() {
-        errorMessage.remove();
-    }, 500);
-}, 5000);
+        var errorMessage = document.querySelector('.error-message');
+        errorMessage.classList.remove('hide');
+
+        setTimeout(function() {
+            errorMessage.classList.add('hide');
+        }, 7000);
+    }, 300);
+});

--- a/grails-app/assets/javascripts/errorMessage.js
+++ b/grails-app/assets/javascripts/errorMessage.js
@@ -1,0 +1,7 @@
+setTimeout(function() {
+    var errorMessage = document.getElementById('error-message');
+    errorMessage.classList.add('hide');
+    setTimeout(function() {
+        errorMessage.remove();
+    }, 500);
+}, 5000);

--- a/grails-app/assets/stylesheets/application.css
+++ b/grails-app/assets/stylesheets/application.css
@@ -5,4 +5,5 @@
 *=require paymentedit
 *=require main
 *=require accountshow
+*=require errornotify
  */

--- a/grails-app/assets/stylesheets/errornotify.css
+++ b/grails-app/assets/stylesheets/errornotify.css
@@ -1,0 +1,27 @@
+.error-message {
+    position: fixed;
+    bottom: 1.25rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #DC3545;
+    color: white;
+    padding: 0.93rem 1.25rem;
+    border-radius: 0.313rem;
+    z-index: 9999;
+    box-shadow: 0 0.25rem 0.375rem rgba(0, 0, 0, 0.1);
+    animation: slideIn 0.5s ease;
+}
+
+.hide {
+    opacity: 0;
+    transition: opacity 0.5s ease;
+}
+
+@keyframes slideIn {
+    from {
+        transform: translateY(100%);
+    }
+    to {
+        transform: translateY(0);
+    }
+}

--- a/grails-app/assets/stylesheets/errornotify.css
+++ b/grails-app/assets/stylesheets/errornotify.css
@@ -5,11 +5,12 @@
     transform: translateX(-50%);
     background-color: #DC3545;
     color: white;
-    padding: 0.93rem 1.25rem;
+    padding: 0 1.25rem;
     border-radius: 0.313rem;
     z-index: 9999;
     box-shadow: 0 0.25rem 0.375rem rgba(0, 0, 0, 0.1);
     animation: slideIn 0.5s ease;
+    white-space: pre-line;
 }
 
 .hide {

--- a/grails-app/assets/stylesheets/errornotify.css
+++ b/grails-app/assets/stylesheets/errornotify.css
@@ -14,7 +14,7 @@
 
 .hide {
     opacity: 0;
-    transition: opacity 0.5s ease;
+    transition: opacity 1s ease;
 }
 
 @keyframes slideIn {

--- a/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
@@ -6,6 +6,7 @@ import com.mini.asaas.utils.message.MessageType
 
 import grails.compiler.GrailsCompileStatic
 import grails.plugin.springsecurity.annotation.Secured
+import grails.validation.ValidationException
 
 @GrailsCompileStatic
 class CustomerController extends BaseController {
@@ -24,10 +25,16 @@ class CustomerController extends BaseController {
             Customer customer = customerService.save(customerAdapter, userAdapter)
 
             redirect(controller: "login", action: "auth")
-        } catch (Exception exception) {
-            log.error("CustomerController.save >> Erro ao cadastrar cliente", exception)
+        } catch (ValidationException validationException) {
+            log.error("CustomerController.save >> Erro ao cadastrar cliente", validationException)
+
+            def errorMessage = "Erro ao salvar os dados, verifique todos os campos e tente novamente."
+            if (validationException.errors) {
+                errorMessage = validationException.errors.allErrors.collect { it.defaultMessage }.join(', ')
+            }
+
             flash.type = MessageType.ERROR
-            flash.message = 'Erro ao salvar os dados, verifique todos os campos e tente novamente.'
+            flash.message = errorMessage
 
             redirect(action: "index")
         }

--- a/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
@@ -25,9 +25,9 @@ class CustomerController extends BaseController {
             Customer customer = customerService.save(customerAdapter, userAdapter)
 
             redirect(controller: "login", action: "auth")
-        } catch (Exception exception) {
-            log.error("CustomerController.save >> Erro ao cadastrar cliente", exception)
         } catch (ValidationException validationException) {
+            log.error("CustomerController.save >> Erro ao cadastrar cliente", validationException)
+
             def errorMessage = "Erro ao salvar os dados, verifique todos os campos e tente novamente."
             if (validationException.errors) {
                 errorMessage = validationException.errors.allErrors.collect { it.defaultMessage }.join(', ')
@@ -35,6 +35,12 @@ class CustomerController extends BaseController {
 
             flash.type = MessageType.ERROR
             flash.message = errorMessage
+
+            redirect(action: "index")
+        } catch (Exception exception) {
+            log.error("CustomerController.save >> Erro ao cadastrar cliente", exception)
+            flash.type = MessageType.ERROR
+            flash.message = "Ocorreu um erro ao salvar os dados."
 
             redirect(action: "index")
         }

--- a/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
@@ -25,9 +25,9 @@ class CustomerController extends BaseController {
             Customer customer = customerService.save(customerAdapter, userAdapter)
 
             redirect(controller: "login", action: "auth")
+        } catch (Exception exception) {
+            log.error("CustomerController.save >> Erro ao cadastrar cliente", exception)
         } catch (ValidationException validationException) {
-            log.error("CustomerController.save >> Erro ao cadastrar cliente", validationException)
-
             def errorMessage = "Erro ao salvar os dados, verifique todos os campos e tente novamente."
             if (validationException.errors) {
                 errorMessage = validationException.errors.allErrors.collect { it.defaultMessage }.join(', ')

--- a/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
+++ b/grails-app/controllers/com/mini/asaas/customer/CustomerController.groovy
@@ -30,7 +30,7 @@ class CustomerController extends BaseController {
 
             def errorMessage = "Erro ao salvar os dados, verifique todos os campos e tente novamente."
             if (validationException.errors) {
-                errorMessage = validationException.errors.allErrors.collect { it.defaultMessage }.join(', ')
+                errorMessage = validationException.errors.allErrors.collect { it.defaultMessage }.join("\n")
             }
 
             flash.type = MessageType.ERROR

--- a/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
@@ -131,6 +131,10 @@ class CustomerService {
             customer.errors.reject("personType", null, "Tipo de pessoa não condiz com campo CPF/CNPJ")
         }
 
+        if (Customer.findByEmail(adapter.email)) {
+            customer.errors.reject("email", null, "Email já cadastrado")
+        }
+
         return customer
     }
 }

--- a/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CustomerService.groovy
@@ -79,6 +79,10 @@ class CustomerService {
             customer.errors.reject("email", null, "Email inválido")
         }
 
+        if (Customer.findByEmail(adapter.email)) {
+            customer.errors.reject("email", null, "Email já cadastrado")
+        }
+
         if (adapter.phone && !PhoneValidator.isValidPhone(adapter.phone)) {
             customer.errors.reject("phone", null, "Telefone inválido")
         }
@@ -129,10 +133,6 @@ class CustomerService {
             customer.errors.reject("personType", null, "Tipo de pessoa não condiz com campo CPF/CNPJ")
         } else if (CpfCnpjValidator.isValidCnpj(adapter.cpfCnpj) && adapter.personType != PersonType.LEGAL) {
             customer.errors.reject("personType", null, "Tipo de pessoa não condiz com campo CPF/CNPJ")
-        }
-
-        if (Customer.findByEmail(adapter.email)) {
-            customer.errors.reject("email", null, "Email já cadastrado")
         }
 
         return customer

--- a/grails-app/views/customer/index.gsp
+++ b/grails-app/views/customer/index.gsp
@@ -6,9 +6,18 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Cadastro de cliente</title>
+        <asset:stylesheet src="errornotify.css"/>
+        <asset:javascript src="errorMessage.js"/>
     </head>
     <body title="Cadastro de cliente">
         <atlas-panel>
+            <div class="error-message hide">
+                <g:if test="${flash.message}">
+                    <div class="alert alert-danger">
+                        ${flash.message}
+                    </div>
+                </g:if>
+            </div>
             <atlas-form method="POST" action="${createLink(controller: 'customer', action: 'save')}">
                 <atlas-grid>
                     <atlas-row>

--- a/grails-app/views/customer/index.gsp
+++ b/grails-app/views/customer/index.gsp
@@ -11,13 +11,7 @@
     </head>
     <body title="Cadastro de cliente">
         <atlas-panel>
-            <div class="error-message hide">
-                <g:if test="${flash.message}">
-                    <div class="alert alert-danger">
-                        ${flash.message}
-                    </div>
-                </g:if>
-            </div>
+            <g:render template="templates/message/errorMessage"/>
             <atlas-form method="POST" action="${createLink(controller: 'customer', action: 'save')}">
                 <atlas-grid>
                     <atlas-row>

--- a/grails-app/views/customer/templates/message/_errorMessage.gsp
+++ b/grails-app/views/customer/templates/message/_errorMessage.gsp
@@ -1,0 +1,7 @@
+<div class="error-message hide">
+    <g:if test="${flash.message}">
+        <div class="alert alert-danger">
+            ${flash.message}
+        </div>
+    </g:if>
+</div>


### PR DESCRIPTION
### Impacto (Descrever o que foi feito)

- Adiciona verificação de email já cadastrado no Service do Customer
- Adiciona um bloco catch no ValidationException para o Controller pegar os erros de campo exibir na View
- Estiliza toast/snackbar em CSS
- Cria função em JS para o toast aparecer na tela carregando mensagens de erro  

### PR Predecessora (Caso exista dependência de uma PR ou branch existente)

### Link da tarefa no GitHub Projects
[Mensagens de erro ao usuário](https://github.com/orgs/TrioParadaDuraa/projects/1/views/1?pane=issue&itemId=65846499)

### Link dos mockups (Se houver)

### Prints do desenvolvimento
![Captura de tela de 2024-06-14 10-19-02](https://github.com/TrioParadaDuraa/mini-asaas/assets/70235376/b109323d-3843-40c5-860f-cca22b3e59d4)
