### PR TITLE
Torna número do endereço opcional

### DIFF
--- a/grails-app/services/com/mini/asaas/customer/CreateCustomerAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/customer/CreateCustomerAdapter.groovy
@@ -22,7 +22,7 @@ class CreateCustomerAdapter extends BasePersonAdapter {
         this.personType = PersonType.convert(params.personType.toString().toUpperCase())
         this.postalCode = Utils.removeNoNumeric(params.postalCode.toString())
         this.address = params.address.toString().trim()
-        this.addressNumber = params.addressNumber.toString().trim()
+        this.addressNumber = params.addressNumber.toString().trim() ?: "S/N"
         this.addressComplement = params.addressComplement.toString().trim() ?: null
         this.district = params.district.toString().trim()
         this.city = params.city.toString().trim()

--- a/grails-app/services/com/mini/asaas/customer/UpdateCustomerAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/customer/UpdateCustomerAdapter.groovy
@@ -9,16 +9,16 @@ import grails.compiler.GrailsCompileStatic
 class UpdateCustomerAdapter extends BasePersonAdapter {
 
     public UpdateCustomerAdapter(Map params){
-        this.name = params.name
+        this.name = params.name.toString().trim()
         this.email = params.email
-        this.phone = Utils.removeNoNumeric(params.phone.toString())
+        this.phone = Utils.removeNoNumeric(params.phone.toString()) ?: null
         this.mobilePhone = Utils.removeNoNumeric(params.mobilePhone.toString())
         this.postalCode = Utils.removeNoNumeric(params.postalCode.toString())
-        this.address = params.address
-        this.addressNumber = params.addressNumber
-        this.addressComplement = (params.addressComplement.toString().trim()) ? params.addressComplement : null
-        this.district = params.district
-        this.city = params.city
-        this.state = params.state
+        this.address = params.address.toString().trim()
+        this.addressNumber = params.addressNumber.toString().trim() ?: "S/N"
+        this.addressComplement = params.addressComplement.toString().trim() ?: null
+        this.district = params.district.toString().trim()
+        this.city = params.city.toString().trim()
+        this.state = params.state.toString().trim()
     }
 }

--- a/grails-app/services/com/mini/asaas/payer/PayerAdapter.groovy
+++ b/grails-app/services/com/mini/asaas/payer/PayerAdapter.groovy
@@ -22,7 +22,7 @@ class PayerAdapter extends BasePersonAdapter {
         this.personType = PersonType.convert(params.personType.toString().toUpperCase())
         this.postalCode = Utils.removeNoNumeric(params.postalCode.toString())
         this.address = params.address.toString().trim()
-        this.addressNumber = params.addressNumber.toString().trim()
+        this.addressNumber = params.addressNumber.toString().trim() ?: "S/N"
         this.addressComplement = params.addressComplement.toString().trim() ?: null
         this.district = params.district.toString().trim()
         this.city = params.city.toString().trim()

--- a/grails-app/views/customer/edit.gsp
+++ b/grails-app/views/customer/edit.gsp
@@ -34,7 +34,7 @@
                         <atlas-input label="Rua/Avenida/Alameda" required="" name="address" size="md" value="${customer.address}"></atlas-input>
                     </atlas-col>
                     <atlas-col lg="4" md="2" sm="1">
-                        <atlas-input label="Número" required="" name="addressNumber" size="md" value="${customer.addressNumber}"></atlas-input>
+                        <atlas-input label="Número" name="addressNumber" size="md" value="${customer.addressNumber}"></atlas-input>
                     </atlas-col>
                     <atlas-col lg="4" md="2" sm="1">
                         <atlas-input label="Complemento" required="" name="addressComplement" size="md" value="${customer.addressComplement}"></atlas-input>

--- a/grails-app/views/customer/index.gsp
+++ b/grails-app/views/customer/index.gsp
@@ -49,7 +49,7 @@
                     </atlas-row>
                     <atlas-row>
                         <atlas-col lg="5" md="3" sm="1">
-                            <atlas-input label="Número" required="" placeholder="Insira o número" name="addressNumber" size="md" value="${params.addressNumber}"></atlas-input>
+                            <atlas-input label="Número" placeholder="Insira o número" name="addressNumber" size="md" value="${params.addressNumber}"></atlas-input>
                         </atlas-col>
                         <atlas-col lg="7" md="3" sm="1">
                             <atlas-input label="Complemento" placeholder="Insira o complemento" name="addressComplement" size="md" value="${params.addressComplement}"></atlas-input>

--- a/grails-app/views/payer/edit.gsp
+++ b/grails-app/views/payer/edit.gsp
@@ -42,7 +42,7 @@
                     </atlas-row>
                     <atlas-row>
                         <atlas-col lg="5" md="3" sm="1">
-                            <atlas-input label="Número" required="" size="md" name="addressNumber" value="${payer.addressNumber}"></atlas-input>
+                            <atlas-input label="Número" size="md" name="addressNumber" value="${payer.addressNumber}"></atlas-input>
                         </atlas-col>
                         <atlas-col lg="7" md="3" sm="1">
                             <atlas-input label="Complemento" size="md" name="addressComplement" value="${payer.addressComplement}"></atlas-input>

--- a/grails-app/views/payer/index.gsp
+++ b/grails-app/views/payer/index.gsp
@@ -50,7 +50,7 @@
                     </atlas-row>
                     <atlas-row>
                         <atlas-col lg="5" md="3" sm="1">
-                            <atlas-input label="Número" required="" placeholder="Insira o número" name="addressNumber" size="md" value="${params.addressNumber}"></atlas-input>
+                            <atlas-input label="Número" placeholder="Insira o número" name="addressNumber" size="md" value="${params.addressNumber}"></atlas-input>
                         </atlas-col>
                         <atlas-col lg="7" md="3" sm="1">
                             <atlas-input label="Complemento" placeholder="Insira o complemento" name="addressComplement" size="md" value="${params.addressComplement}"></atlas-input>


### PR DESCRIPTION
### Impacto

- Torna número do endereço opcional
- Mudança feita para tornar o preenchimento do formulário mais intuitivo
caso o usuário queira utilizar um endereço sem número. Dessa forma,
basta deixar o campo em branco
- Também atualiza o código de alguns adapters

### PR Predecessora

### Link da tarefa no GitHub Projects

### Link dos mockups

### Prints do desenvolvimento
